### PR TITLE
Remove 386 library architecture dependencies

### DIFF
--- a/ubuntu-19.04-clang-8.0-runtime-2.0/GNUstep-buildon-ubuntu1904.sh
+++ b/ubuntu-19.04-clang-8.0-runtime-2.0/GNUstep-buildon-ubuntu1904.sh
@@ -24,11 +24,10 @@ sudo apt update
 
 echo -e "\n\n${GREEN}Installing dependencies...${NC}"
 
-sudo dpkg --add-architecture i386  # Enable 32-bit repos for libx11-dev:i386
 sudo apt-get update
 sudo apt -y install clang git cmake libffi-dev libxml2-dev \
 libgnutls28-dev libicu-dev libblocksruntime-dev libkqueue-dev libpthread-workqueue-dev autoconf libtool \
-libjpeg-dev libtiff-dev libffi-dev libcairo-dev libx11-dev:i386 libxt-dev libxft-dev
+libjpeg-dev libtiff-dev libffi-dev libcairo-dev libx11-dev libxt-dev libxft-dev
 
 if [ "$APPS" = true ] ; then
   sudo apt -y install curl


### PR DESCRIPTION
a long time ago, we were dependent on some 386 X11 dev dependencies.
Looks like that is no longer the case -- removing the need for that architecture will make it easy for us to have a double-clickable deb installable via software center.