### PR TITLE
Use $RUNTIME_VERSION value when adding to bashrc

### DIFF
--- a/debian-9-clang-8.0-runtime-2.0/GNUstep-buildon-debian9.sh
+++ b/debian-9-clang-8.0-runtime-2.0/GNUstep-buildon-debian9.sh
@@ -184,7 +184,7 @@ echo $OBJCFLAGS
 . /usr/GNUstep/System/Library/Makefiles/GNUstep.sh
 echo $LDFLAGS
 echo $OBJCFLAGS
-echo "export RUNTIME_VERSION=gnustep-2.0"  >> ~/.bashrc
+echo "export RUNTIME_VERSION=$RUNTIME_VERSION"  >> ~/.bashrc
 echo "export LD=/usr/bin/ld.gold" >> ~/.bashrc
 echo ". /usr/GNUstep/System/Library/Makefiles/GNUstep.sh" >> ~/.bashrc
 


### PR DESCRIPTION
This change makes sure that the line appended to bashrc uses the same RUNTIME_VERSION that is used during build.
