### PR TITLE
initial build and test for Ubuntu20.04

### DIFF
--- a/ubuntu-20.04-clang-10.0-runtime-2.0/GNUstep-buildon-ubuntu2004.sh
+++ b/ubuntu-20.04-clang-10.0-runtime-2.0/GNUstep-buildon-ubuntu2004.sh
@@ -1,0 +1,225 @@
+#!/bin/bash
+
+# Show prompt function
+function showPrompt()
+{
+  if [ "$PROMPT" = true ] ; then
+    echo -e "\n\n"
+    read -p "${GREEN}Press enter to continue...${NC}"
+  fi
+}
+
+# Set colors
+GREEN=`tput setaf 2`
+NC=`tput sgr0` # No Color
+
+# Set to true to also build and install apps
+APPS=false
+
+# Set to true to pause after each build to verify successful build and installation
+PROMPT=false
+
+# Install Requirements
+sudo apt update
+
+echo -e "\n\n${GREEN}Installing dependencies...${NC}"
+
+sudo apt-get update
+sudo apt -y install clang build-essential wget git subversion cmake libffi-dev libxml2-dev \
+libgnutls28-dev libicu-dev libblocksruntime-dev libkqueue-dev libpthread-workqueue-dev autoconf libtool \
+libjpeg-dev libtiff-dev libffi-dev libcairo-dev libx11-dev libxt-dev libxft-dev libxrandr-dev
+
+if [ "$APPS" = true ] ; then
+  sudo apt -y install curl
+fi
+
+# Create build directory
+mkdir GNUstep-build
+cd GNUstep-build
+
+# Set clang as compiler
+export CC=clang
+export CXX=clang++
+export CXXFLAGS="-std=c++11"
+export RUNTIME_VERSION=gnustep-2.0
+export PKG_CONFIG_PATH=/usr/local/lib/pkgconfig
+export LD=/usr/bin/ld.gold
+export LDFLAGS="-fuse-ld=/usr/bin/ld.gold -L/usr/local/lib"
+
+
+# Checkout sources
+echo -e "\n\n${GREEN}Checking out sources...${NC}"
+git clone https://github.com/apple/swift-corelibs-libdispatch
+cd swift-corelibs-libdispatch
+  git checkout swift-5.2.2-RELEASE
+cd ..
+git clone https://github.com/gnustep/libobjc2.git
+cd libobjc2
+  git submodule init
+  git submodule sync
+  git submodule update
+cd ..
+git clone https://github.com/gnustep/tools-make.git
+git clone https://github.com/gnustep/libs-base.git
+git clone https://github.com/gnustep/libs-gui.git
+git clone https://github.com/gnustep/libs-back.git
+
+if [ "$APPS" = true ] ; then
+  git clone https://github.com/gnustep/apps-projectcenter.git
+  git clone https://github.com/gnustep/apps-gorm.git
+  svn co http://svn.savannah.nongnu.org/svn/gap/trunk/libs/PDFKit/
+  git clone https://github.com/gnustep/apps-gworkspace.git
+  git clone https://github.com/gnustep/apps-systempreferences.git
+fi
+
+set -e
+showPrompt
+
+# Build GNUstep make first time
+echo -e "\n\n"
+echo -e "${GREEN}Building GNUstep-make for the first time...${NC}"
+cd tools-make
+# git checkout `git rev-list -1 --first-parent --before=2017-04-06 master` # fixes segfault, should probably be looked at.
+#./configure --enable-debug-by-default --with-layout=gnustep  --enable-objc-arc  --with-library-combo=ng-gnu-gnu
+  CC=$CC ./configure \
+          --with-layout=gnustep \
+              --disable-importing-config-file \
+                  --enable-native-objc-exceptions \
+                      --enable-objc-arc \
+                          --enable-install-ld-so-conf \
+                              --with-library-combo=ng-gnu-gnu
+
+make -j8
+sudo -E make install
+
+. /usr/GNUstep/System/Library/Makefiles/GNUstep.sh
+echo ". /usr/GNUstep/System/Library/Makefiles/GNUstep.sh" >> ~/.bashrc
+echo "export RUNTIME_VERSION=$RUNTIME_VERSION" >> ~/.bashrc
+echo 'export CXXFLAGS="-std=c++11"' >> ~/.bashrc
+
+
+showPrompt
+
+# Build libdispatch
+echo -e "\n\n"
+echo -e "${GREEN}Building libdispatch...${NC}"
+cd ../swift-corelibs-libdispatch
+rm -Rf build
+mkdir build && cd build
+cmake .. -DCMAKE_C_COMPILER=${CC} \
+-DCMAKE_CXX_COMPILER=${CXX} \
+-DCMAKE_BUILD_TYPE=Release \
+-DUSE_GOLD_LINKER=YES
+make
+sudo -E make install
+sudo ldconfig
+
+showPrompt
+
+# Build libobjc2
+echo -e "\n\n"
+echo -e "${GREEN}Building libobjc2...${NC}"
+cd ../../libobjc2
+rm -Rf build
+mkdir build && cd build
+cmake ../ -DCMAKE_C_COMPILER=$CC -DCMAKE_CXX_COMPILER=$CXX -DCMAKE_ASM_COMPILER=$CC -DTESTS=OFF
+cmake --build .
+sudo -E make install
+sudo ldconfig
+
+showPrompt
+
+# Build GNUstep make second time
+echo -e "\n\n"
+echo -e "${GREEN}Building GNUstep-make for the second time...${NC}"
+cd ../../tools-make
+#./configure --enable-debug-by-default --with-layout=gnustep --enable-objc-arc --with-library-combo=ng-gnu-gnu
+  CC=$CC ./configure \
+          --with-layout=gnustep \
+              --disable-importing-config-file \
+                  --enable-native-objc-exceptions \
+                      --enable-objc-arc \
+                          --enable-install-ld-so-conf \
+                              --with-library-combo=ng-gnu-gnu
+
+make -j8
+sudo -E make install
+
+. /usr/GNUstep/System/Library/Makefiles/GNUstep.sh
+
+showPrompt
+
+# Build GNUstep base
+echo -e "\n\n"
+echo -e "${GREEN}Building GNUstep-base...${NC}"
+cd ../libs-base/
+./configure
+make -j8
+sudo -E make install
+
+showPrompt
+
+# Build GNUstep GUI
+echo -e "\n\n"
+echo -e "${GREEN} Building GNUstep-gui...${NC}"
+cd ../libs-gui
+./configure
+make -j8
+sudo -E make install
+
+showPrompt
+
+# Build GNUstep back
+echo -e "\n\n"
+echo -e "${GREEN}Building GNUstep-back...${NC}"
+cd ../libs-back
+./configure
+make -j8
+sudo -E make install
+
+showPrompt
+
+. /usr/GNUstep/System/Library/Makefiles/GNUstep.sh
+
+if [ "$APPS" = true ] ; then
+  echo -e "${GREEN}Building ProjectCenter...${NC}"
+  cd ../apps-projectcenter/
+  make -j8
+  sudo -E make install
+
+  showPrompt
+
+  echo -e "${GREEN}Building Gorm...${NC}"
+  cd ../apps-gorm/
+  make -j8
+  sudo -E make install
+
+  showPrompt
+
+  echo -e "${GREEN}Building PDFKit...${NC}"
+  cd ../PDFKit/
+  ./configure
+  make -j8
+  sudo -E make install
+
+  showPrompt
+
+  echo -e "\n\n"
+  echo -e "${GREEN}Building GWorkspace...${NC}"
+  cd ../apps-gworkspace/
+  ./configure
+  make -j8
+  sudo -E make install
+
+  showPrompt
+
+  echo -e "\n\n"
+  echo -e "${GREEN}Building SystemPreferences...${NC}"
+  cd ../apps-systempreferences/
+  make -j8
+  sudo -E make install
+
+fi
+
+echo -e "\n\n"
+echo -e "${GREEN}Install is done. Open a new terminal to start using.${NC}"

--- a/ubuntu-20.04-clang-10.0-runtime-2.0/libobjc2-teston-ubuntu2004.sh
+++ b/ubuntu-20.04-clang-10.0-runtime-2.0/libobjc2-teston-ubuntu2004.sh
@@ -1,0 +1,82 @@
+#!/bin/bash
+
+sudo apt-get update
+sudo apt -y install clang build-essential wget git subversion cmake libffi-dev libxml2-dev \
+libgnutls28-dev libicu-dev libblocksruntime-dev libkqueue-dev libpthread-workqueue-dev autoconf libtool \
+libjpeg-dev libtiff-dev libffi-dev libcairo-dev libx11-dev libxt-dev libxft-dev
+
+# Create build directory
+mkdir GNUstep-build
+cd GNUstep-build
+
+# Set clang as compiler
+export CC=clang
+export CXX=clang++
+export CXXFLAGS="-std=c++11"
+export RUNTIME_VERSION=gnustep-2.0
+export PKG_CONFIG_PATH=/usr/local/lib/pkgconfig
+export LD=/usr/bin/ld.gold
+export LDFLAGS="-fuse-ld=/usr/bin/ld.gold -L/usr/local/lib"
+
+
+# Checkout sources
+echo -e "\n\n${GREEN}Checking out sources...${NC}"
+git clone https://github.com/apple/swift-corelibs-libdispatch
+cd swift-corelibs-libdispatch
+  git checkout swift-5.2.2-RELEASE
+cd ..
+git clone https://github.com/gnustep/libobjc2.git
+cd libobjc2
+  git submodule init
+  git submodule sync
+  git submodule update
+cd ..
+git clone https://github.com/gnustep/tools-make.git
+
+# Build GNUstep make first time
+echo -e "\n\n"
+echo -e "${GREEN}Building GNUstep-make for the first time...${NC}"
+cd tools-make
+# git checkout `git rev-list -1 --first-parent --before=2017-04-06 master` # fixes segfault, should probably be looked at.
+#./configure --enable-debug-by-default --with-layout=gnustep  --enable-objc-arc  --with-library-combo=ng-gnu-gnu
+  CC=$CC ./configure \
+          --with-layout=gnustep \
+              --disable-importing-config-file \
+                  --enable-native-objc-exceptions \
+                      --enable-objc-arc \
+                          --enable-install-ld-so-conf \
+                              --with-library-combo=ng-gnu-gnu
+
+make -j8
+sudo -E make install
+
+. /usr/GNUstep/System/Library/Makefiles/GNUstep.sh
+echo ". /usr/GNUstep/System/Library/Makefiles/GNUstep.sh" >> ~/.bashrc
+echo "export RUNTIME_VERSION=gnustep-2.0" >> ~/.bashrc
+echo 'export CXXFLAGS="-std=c++11"' >> ~/.bashrc
+
+
+# Build libdispatch
+echo -e "\n\n"
+echo -e "${GREEN}Building libdispatch...${NC}"
+cd ../swift-corelibs-libdispatch
+rm -Rf build
+mkdir build && cd build
+cmake .. -DCMAKE_C_COMPILER=${CC} \
+-DCMAKE_CXX_COMPILER=${CXX} \
+-DCMAKE_BUILD_TYPE=Release \
+-DUSE_GOLD_LINKER=YES
+make
+sudo -E make install
+sudo ldconfig
+
+# Build libobjc2
+echo -e "\n\n"
+echo -e "${GREEN}Building libobjc2...${NC}"
+cd ../../libobjc2
+rm -Rf build
+mkdir build && cd build
+cmake ../ -DCMAKE_C_COMPILER=$CC -DCMAKE_CXX_COMPILER=$CXX -DCMAKE_ASM_COMPILER=$CC -DTESTS=ON
+cmake --build .
+make test
+

--- a/ubuntu-20.04-clang-10.0-runtime-2.0/test-libobjc2.sh
+++ b/ubuntu-20.04-clang-10.0-runtime-2.0/test-libobjc2.sh
@@ -1,0 +1,2 @@
+docker build -t gnustep-clang-ubuntu2004-libobjc2 testing-libobjc2/.
+docker run gnustep-clang-ubuntu2004-libobjc2

--- a/ubuntu-20.04-clang-10.0-runtime-2.0/test.sh
+++ b/ubuntu-20.04-clang-10.0-runtime-2.0/test.sh
@@ -1,0 +1,2 @@
+docker build -t gnustep-clang-ubuntu2004 testing/.
+docker run gnustep-clang-ubuntu2004

--- a/ubuntu-20.04-clang-10.0-runtime-2.0/testing-libobjc2/Dockerfile
+++ b/ubuntu-20.04-clang-10.0-runtime-2.0/testing-libobjc2/Dockerfile
@@ -1,7 +1,9 @@
 FROM ubuntu:20.04
 
+ENV TZ=America/Los_Angeles
+RUN ln -snf /usr/share/zoneinfo/$TZ /etc/localtime && echo $TZ > /dev/timezone
 RUN apt-get update && apt-get install -y git sudo
-RUN git clone https://github.com/plaurent/gnustep-build
+RUN git clone https://github.com/sheffler/gnustep-build
 RUN cp gnustep-build/*.sh .
 RUN cp gnustep-build/ubuntu-20.04-clang-10.0-runtime-2.0/*.sh .
 RUN cp gnustep-build/ubuntu-20.04-clang-10.0-runtime-2.0/testing/Dockerfile .

--- a/ubuntu-20.04-clang-10.0-runtime-2.0/testing-libobjc2/Dockerfile
+++ b/ubuntu-20.04-clang-10.0-runtime-2.0/testing-libobjc2/Dockerfile
@@ -1,0 +1,10 @@
+FROM ubuntu:20.04
+
+RUN apt-get update && apt-get install -y git sudo
+RUN git clone https://github.com/plaurent/gnustep-build
+RUN cp gnustep-build/*.sh .
+RUN cp gnustep-build/ubuntu-20.04-clang-10.0-runtime-2.0/*.sh .
+RUN cp gnustep-build/ubuntu-20.04-clang-10.0-runtime-2.0/testing/Dockerfile .
+RUN chmod +x *.sh
+
+CMD [ "/bin/bash", "-c", "export PS1=allow_bash_to_run; source ~/.bashrc; ./libobjc2-teston-ubuntu2004.sh" ]

--- a/ubuntu-20.04-clang-10.0-runtime-2.0/testing-libobjc2/Dockerfile
+++ b/ubuntu-20.04-clang-10.0-runtime-2.0/testing-libobjc2/Dockerfile
@@ -3,7 +3,7 @@ FROM ubuntu:20.04
 ENV TZ=America/Los_Angeles
 RUN ln -snf /usr/share/zoneinfo/$TZ /etc/localtime && echo $TZ > /dev/timezone
 RUN apt-get update && apt-get install -y git sudo
-RUN git clone https://github.com/sheffler/gnustep-build
+RUN git clone https://github.com/plaurent/gnustep-build
 RUN cp gnustep-build/*.sh .
 RUN cp gnustep-build/ubuntu-20.04-clang-10.0-runtime-2.0/*.sh .
 RUN cp gnustep-build/ubuntu-20.04-clang-10.0-runtime-2.0/testing/Dockerfile .

--- a/ubuntu-20.04-clang-10.0-runtime-2.0/testing/Dockerfile
+++ b/ubuntu-20.04-clang-10.0-runtime-2.0/testing/Dockerfile
@@ -1,7 +1,9 @@
 FROM ubuntu:20.04
 
+ENV TZ=America/Los_Angeles
+RUN ln -snf /usr/share/zoneinfo/$TZ /etc/localtime && echo $TZ > /dev/timezone
 RUN apt-get update && apt-get install -y git sudo
-RUN git clone https://github.com/plaurent/gnustep-build
+RUN git clone https://github.com/sheffler/gnustep-build
 RUN cp gnustep-build/*.sh .
 RUN cp gnustep-build/ubuntu-20.04-clang-10.0-runtime-2.0/*.sh .
 RUN cp gnustep-build/ubuntu-20.04-clang-10.0-runtime-2.0/testing/Dockerfile .

--- a/ubuntu-20.04-clang-10.0-runtime-2.0/testing/Dockerfile
+++ b/ubuntu-20.04-clang-10.0-runtime-2.0/testing/Dockerfile
@@ -1,0 +1,12 @@
+FROM ubuntu:20.04
+
+RUN apt-get update && apt-get install -y git sudo
+RUN git clone https://github.com/plaurent/gnustep-build
+RUN cp gnustep-build/*.sh .
+RUN cp gnustep-build/ubuntu-20.04-clang-10.0-runtime-2.0/*.sh .
+RUN cp gnustep-build/ubuntu-20.04-clang-10.0-runtime-2.0/testing/Dockerfile .
+RUN chmod +x *.sh
+RUN /bin/bash -c "./GNUstep-buildon-ubuntu2004.sh"
+RUN [ "/bin/bash", "-c", "export PS1=allow_bash_to_run; source ~/.bashrc; ./demo.sh" ]
+
+CMD [ "/bin/bash", "-c", "export PS1=allow_bash_to_run; source ~/.bashrc; ./demo.sh" ]

--- a/ubuntu-20.04-clang-10.0-runtime-2.0/testing/Dockerfile
+++ b/ubuntu-20.04-clang-10.0-runtime-2.0/testing/Dockerfile
@@ -3,7 +3,7 @@ FROM ubuntu:20.04
 ENV TZ=America/Los_Angeles
 RUN ln -snf /usr/share/zoneinfo/$TZ /etc/localtime && echo $TZ > /dev/timezone
 RUN apt-get update && apt-get install -y git sudo
-RUN git clone https://github.com/sheffler/gnustep-build
+RUN git clone https://github.com/plaurent/gnustep-build
 RUN cp gnustep-build/*.sh .
 RUN cp gnustep-build/ubuntu-20.04-clang-10.0-runtime-2.0/*.sh .
 RUN cp gnustep-build/ubuntu-20.04-clang-10.0-runtime-2.0/testing/Dockerfile .


### PR DESCRIPTION
Changes for Ubuntu20.04 from Ubuntu19.10
- 'apt install clang' pulls 'clang-10' in Ubntu20.04
- bump libdispatch to 5.2.2

Creates a working gnustep-environment in Ubuntu 20.04.

Docker testing:
* ./test.sh emits some warnings
* ./test-libobjc2.sh : two tests fail (see below)

```
99% tests passed, 2 tests failed out of 186

Total Test time (real) =  30.13 sec

The following tests FAILED:
	 63 - PropertyAttributeTest_legacy (Child aborted)
	 64 - PropertyAttributeTest_legacy_optimised (Child aborted)
Errors while running CTest
make: *** [Makefile:97: test] Error 8
```