### PR TITLE
add docker creation to 'ubuntu-16.04-clang-9.0-runtime-2.0-ARM'

### DIFF
--- a/ubuntu-16.04-clang-9.0-runtime-2.0-ARM/test.sh
+++ b/ubuntu-16.04-clang-9.0-runtime-2.0-ARM/test.sh
@@ -1,0 +1,2 @@
+docker build -t gnustep-clang-ubuntu1604 testing/.
+docker run gnustep-clang-ubuntu1604

--- a/ubuntu-16.04-clang-9.0-runtime-2.0-ARM/testing/Dockerfile
+++ b/ubuntu-16.04-clang-9.0-runtime-2.0-ARM/testing/Dockerfile
@@ -1,0 +1,10 @@
+FROM ubuntu:16.04
+
+RUN apt-get update && apt-get install -y clang build-essential wget git sudo
+RUN git clone https://github.com/plaurent/gnustep-build
+RUN cp gnustep-build/*.sh .
+RUN cp gnustep-build/ubuntu-16.04-clang-9.0-runtime-2.0-ARM/*.sh .
+RUN chmod +x *.sh
+RUN /bin/bash -c "./GNUstep-buildon-ubuntu1604_arm.sh"
+
+CMD [ "/bin/bash", "-c", "export PS1=allow_bash_to_run; source ~/.bashrc; ./demo.sh" ]


### PR DESCRIPTION
adapted from the clang-6/1.9 runtime version.

Background: 

- docker needed because that's how I get Linux on my M1 Mac
- the 1.9 runtime version didn't compile gstep-base for me
- adapting the Dockerfile from Ubuntu-2010 latest failed with the now familiar "C compiler couldn't create executables" error when configuring
