### PR TITLE
Fix swift-corelibs-libdispatch version

### DIFF
--- a/ubuntu-20.04-clang-10.0-runtime-2.0/GNUstep-buildon-ubuntu2004.sh
+++ b/ubuntu-20.04-clang-10.0-runtime-2.0/GNUstep-buildon-ubuntu2004.sh
@@ -51,7 +51,7 @@ export LDFLAGS="-fuse-ld=/usr/bin/ld.gold -L/usr/local/lib"
 
 # Checkout sources
 echo -e "\n\n${GREEN}Checking out sources...${NC}"
-git clone https://github.com/apple/swift-corelibs-libdispatch
+git clone --branch swift-5.10.1-RELEASE https://github.com/apple/swift-corelibs-libdispatch
 #cd swift-corelibs-libdispatch
 #  git checkout swift-5.2.2-RELEASE
 #cd ..


### PR DESCRIPTION
In the scope of the https://github.com/apple/swift-corelibs-libdispatch/pull/832, `swift-corelibs-libdispatch` started relying on the `CheckLinkerFlag` module (https://cmake.org/cmake/help/latest/module/CheckLinkerFlag.html), which is accessible starting from CMake version 3.18. By default, CMake 3.16 is installed on Ubuntu 20, which makes the build fail.

To solve this, fixed the `swift-corelibs-libdispatch` repository to tag `swift-5.10.1-RELEASE`, which is the latest release, and doesn't contain the problematic change.